### PR TITLE
fix: remove byte size check to support iOS

### DIFF
--- a/lib/threema/receive/file.rb
+++ b/lib/threema/receive/file.rb
@@ -16,8 +16,6 @@ class Threema
 
         download = blob.download(structure['b'])
 
-        raise "Bytesize doesn't match" if download.bytesize != structure['s']
-
         @content = Threema::E2e::SecretKey.decrypt(
           data:  download,
           key:   Threema::Util.unhexify(structure['k']),

--- a/lib/threema/receive/image.rb
+++ b/lib/threema/receive/image.rb
@@ -16,8 +16,6 @@ class Threema
         blob     = Threema::Blob.new(threema: threema)
         download = blob.download(blob_id)
 
-        raise "Bytesize doesn't match" if download.bytesize != crypted_byte_string_size
-
         @content = Threema::E2e::PublicKey.decrypt(
           data:        download,
           private_key: threema.private_key,

--- a/spec/threema/receive/file_spec.rb
+++ b/spec/threema/receive/file_spec.rb
@@ -52,39 +52,4 @@ RSpec.describe Threema::Receive::File do
   it 'returns file name' do
     expect(instance.name).to eq(filename)
   end
-
-  it "raises a RuntimeError if filsize doesn't match" do
-    secret_key = Threema::E2e::SecretKey.generate
-    encrypted  = Threema::E2e::SecretKey.encrypt(
-      key:   secret_key,
-      data:  content,
-      nonce: Threema::E2e::File::NONCE[:file],
-    )
-
-    blob_id = test_blob_id
-    payload = JSON.generate(
-      'b' => blob_id,
-      'k' => Threema::Util.hexify(secret_key),
-      'm' => mime_type,
-      'n' => filename,
-      's' => encrypted.bytesize + 1,
-      'i' => 0,
-    )
-
-    stub_request(:get, Threema::Blob.download_url(blob_id))
-      .with(
-        query: test_auth_params
-      )
-      .to_return(
-        status: 200,
-        body:   encrypted
-      )
-
-    expect do
-      described_class.new(
-        content: payload,
-        threema: build(:threema)
-      )
-    end.to raise_error(RuntimeError)
-  end
 end


### PR DESCRIPTION
From Threema Gateway Support:

> Guten Tag Herr Schäfer
>
> Besten Dank für Ihre Nachricht. Da gibt es tatsächlich eine implementationsspezifische
> Abweichung beim Feld "s": die iOS-App fasst dieses als Grösse der Originaldatei vor der
> Verschlüsselung auf, die Android-App nach der Verschlüsselung (wodurch 16 Bytes für den
> MAC dazukommen).
>
> Das Feld "s" dient nur als ungefähre Indikation für den Empfänger, wie gross die Datei
> ist, damit er entscheiden kann, ob sie sofort heruntergeladen werden soll, oder z.B. erst
> im WLAN. Es hat keine Sicherheitsrelevanz, denn die Integrität und Vollständigkeit wird
> bereits durch das NaCl Box-Modell gewährleistet. Es ist also nicht nötig, die Länge der
> heruntergeladenen Datei mit dem Feld "s" zu vergleichen.
>
> Beste Grüsse,

English translation

> Hello Mr. Schäfer
>
> Thank you very much for your message. There is indeed an implementation-specific
> difference in the "s" field: the iOS app interprets this as the size of the original file before encryption, the
> encryption, the Android app after the encryption (which adds 16 bytes for the
> MAC).
>
> The "s" field only serves as an approximate indication for the recipient of how big the file
> file is, so that he can decide e.g. whether it should be downloaded immediately or only
> in the WLAN. It has no security relevance, because the integrity and completeness is
> is already guaranteed by the NaCl Box model. It is therefore not necessary to specify the length of the
> downloaded file with the "s" field.
>
> Best regards,

@mattwr18's rebased commit message:

> we will look into whether this is a security issue, but it seems there is a
> difference in how threema-android and threema-ios sign their encrytped strings
> and there is a 16-byte authenticator for android, but not for ios. Anyways, we
> rely on decrypt to validate the authenticity of the nonce, and therefore the
> sender

fix #17