### PR TITLE
fix: HTTP response code "Payload too large"

### DIFF
--- a/lib/threema/blob.rb
+++ b/lib/threema/blob.rb
@@ -45,7 +45,7 @@ class Threema
       case e.message
       when 'Net::HTTPBadRequest'
         message = 'required parameters are missing or the file is empty'
-      when 'Net::HTTPRequestEntityTooLarge'
+      when 'Net::HTTPPayloadTooLarge'
         message = 'file is too big'
       else
         raise

--- a/lib/threema/send.rb
+++ b/lib/threema/send.rb
@@ -70,7 +70,7 @@ class Threema
         @threema.client.post_form_urlencoded(self.class.url(type), message.payload)
       end
     rescue RequestError => e
-      raise if e.message != 'Net::HTTPRequestEntityTooLarge'
+      raise if e.message != 'Net::HTTPPayloadTooLarge'
       raise ArgumentError, 'message is too long'
     end
   end

--- a/spec/threema/blob_spec.rb
+++ b/spec/threema/blob_spec.rb
@@ -125,7 +125,7 @@ RSpec.describe Threema::Blob do
         expect { filehandle_upload }.to raise_error(ArgumentError)
       end
 
-      it 'raises ArgumentError exception for HTTP RequestEntityTooLarge response' do
+      it 'raises ArgumentError exception for HTTP PayloadTooLarge response' do
         mock_error(413)
         expect { filehandle_upload }.to raise_error(ArgumentError)
       end

--- a/spec/threema/send_spec.rb
+++ b/spec/threema/send_spec.rb
@@ -145,7 +145,7 @@ RSpec.describe Threema::Send do
         expect { method_call }.to raise_error(ArgumentError)
       end
 
-      it 'raises ArgumentError exception for HTTP RequestEntityTooLarge response' do
+      it 'raises ArgumentError exception for HTTP PayloadTooLarge response' do
         mock_simple_error(413)
         expect { method_call }.to raise_error(ArgumentError)
       end


### PR DESCRIPTION
It *looks* like something outdated again, but I'm still confused with
this.

MDN docs only reference "Payload too large":
https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/413

In ruby stdlib documentation I find both the two constants
`HTTPRequestEntityTooLarge` and `Net::HTTPPayloadTooLarge`.
https://ruby-doc.org/stdlib-2.6.3/libdoc/net/http/rdoc/Net/HTTPPayloadTooLarge.html

Entering 'Net::HTTPPayloadTooLarge' on the ruby Github repository gives
me:
https://github.com/ruby/ruby/blob/48b94b791997881929c739c64f95ac30f3fd0bb9/lib/net/http/responses.rb#L144

The respective commit that changed it:
https://github.com/ruby/ruby/commit/660740a75dd9526ad9a2732ea87c8ab5a385ef1f

The commit message is not very telling and so I am guessing it's a simple
renaming to match the title of the HTTP 413 status code.

This commit fixes one test case on my machine.