### PR TITLE
refactor: update almost all development deps

### DIFF
--- a/spec/factories/threema.rb
+++ b/spec/factories/threema.rb
@@ -1,7 +1,7 @@
-FactoryGirl.define do
+FactoryBot.define do
   factory :threema do
-    api_identity test_from
-    api_secret   test_api_secret
+    api_identity { test_from }
+    api_secret   { test_api_secret }
 
     initialize_with do
       new(attributes)

--- a/spec/factories/threema_account.rb
+++ b/spec/factories/threema_account.rb
@@ -1,6 +1,6 @@
-FactoryGirl.define do
+FactoryBot.define do
   factory :threema_account, class: Threema::Account do
-    threema { FactoryGirl.build(:threema) }
+    threema { FactoryBot.build(:threema) }
 
     initialize_with do
       new(attributes)

--- a/spec/factories/threema_blob.rb
+++ b/spec/factories/threema_blob.rb
@@ -1,6 +1,6 @@
-FactoryGirl.define do
+FactoryBot.define do
   factory :threema_blob, class: Threema::Blob do
-    threema { FactoryGirl.build(:threema) }
+    threema { FactoryBot.build(:threema) }
 
     initialize_with do
       new(attributes)

--- a/spec/factories/threema_capabilities.rb
+++ b/spec/factories/threema_capabilities.rb
@@ -1,6 +1,6 @@
-FactoryGirl.define do
+FactoryBot.define do
   factory :threema_capabilities, class: Threema::Capabilities do
-    threema { FactoryGirl.build(:threema) }
+    threema { FactoryBot.build(:threema) }
 
     initialize_with do
       new(attributes)

--- a/spec/factories/threema_client.rb
+++ b/spec/factories/threema_client.rb
@@ -1,7 +1,7 @@
-FactoryGirl.define do
+FactoryBot.define do
   factory :threema_client, class: Threema::Client do
-    api_identity test_from
-    api_secret   test_api_secret
+    api_identity { test_from }
+    api_secret   { test_api_secret }
 
     initialize_with do
       new(attributes)

--- a/spec/factories/threema_file_message.rb
+++ b/spec/factories/threema_file_message.rb
@@ -1,10 +1,10 @@
 require 'tempfile'
 
-FactoryGirl.define do
+FactoryBot.define do
   factory :file_message, class: Threema::Send::File do
-    threema    { FactoryGirl.build(:threema) }
-    threema_id test_threema_id
-    file       hello_world.b
+    threema    { FactoryBot.build(:threema) }
+    threema_id { test_threema_id }
+    file       { hello_world.b }
 
     initialize_with do
       new(attributes)

--- a/spec/factories/threema_image_message.rb
+++ b/spec/factories/threema_image_message.rb
@@ -1,10 +1,10 @@
 require 'tempfile'
 
-FactoryGirl.define do
+FactoryBot.define do
   factory :image_message, class: Threema::Send::Image do
-    threema    { FactoryGirl.build(:threema) }
-    threema_id test_threema_id
-    image      'imagecontent'.b
+    threema    { FactoryBot.build(:threema) }
+    threema_id { test_threema_id }
+    image      { 'imagecontent'.b }
 
     initialize_with do
       new(attributes)

--- a/spec/factories/threema_lookup.rb
+++ b/spec/factories/threema_lookup.rb
@@ -1,6 +1,6 @@
-FactoryGirl.define do
+FactoryBot.define do
   factory :threema_lookup, class: Threema::Lookup do
-    threema { FactoryGirl.build(:threema) }
+    threema { FactoryBot.build(:threema) }
 
     initialize_with do
       new(attributes)

--- a/spec/factories/threema_send.rb
+++ b/spec/factories/threema_send.rb
@@ -1,6 +1,6 @@
-FactoryGirl.define do
+FactoryBot.define do
   factory :threema_send, class: Threema::Send do
-    threema { FactoryGirl.build(:threema) }
+    threema { FactoryBot.build(:threema) }
 
     initialize_with do
       new(attributes)

--- a/spec/factories/threema_simple_message.rb
+++ b/spec/factories/threema_simple_message.rb
@@ -1,7 +1,7 @@
-FactoryGirl.define do
+FactoryBot.define do
   factory :simple_message_threema_id, class: Threema::Send::Simple do
-    threema_id test_threema_id
-    text       hello_world
+    threema_id { test_threema_id }
+    text       { hello_world }
 
     initialize_with do
       new(attributes)
@@ -9,8 +9,8 @@ FactoryGirl.define do
   end
 
   factory :simple_message_phone, class: Threema::Send::Simple do
-    phone '41791234567'
-    text  hello_world
+    phone {' 41791234567 '}
+    text  { hello_world }
 
     initialize_with do
       new(attributes)
@@ -18,8 +18,8 @@ FactoryGirl.define do
   end
 
   factory :simple_message_email, class: Threema::Send::Simple do
-    email 'test@threema.ch'
-    text  hello_world
+    email {' test @threema.ch'}
+    text  { hello_world }
 
     initialize_with do
       new(attributes)

--- a/spec/factories/threema_text_message.rb
+++ b/spec/factories/threema_text_message.rb
@@ -1,9 +1,9 @@
-FactoryGirl.define do
+FactoryBot.define do
   factory :text_message, class: Threema::Send::Text do
-    threema    { FactoryGirl.build(:threema) }
-    threema_id test_threema_id
-    text       hello_world
-    public_key nil
+    threema    { FactoryBot.build(:threema) }
+    threema_id { test_threema_id }
+    text       { hello_world }
+    public_key { nil }
 
     initialize_with do
       new(attributes)

--- a/spec/factories/threema_text_receive.rb
+++ b/spec/factories/threema_text_receive.rb
@@ -1,6 +1,6 @@
-FactoryGirl.define do
+FactoryBot.define do
   factory :text_receive, class: Threema::Receive::Text do
-    content hello_world
+    content { hello_world }
 
     initialize_with do
       new(attributes)

--- a/spec/factories/threema_typed_message.rb
+++ b/spec/factories/threema_typed_message.rb
@@ -1,6 +1,6 @@
-FactoryGirl.define do
+FactoryBot.define do
   factory :typed_message_typed, class: Threema::TypedMessage do
-    typed "\x01Hello World"
+    typed { "\x01Hello World" }
 
     initialize_with do
       new(attributes)
@@ -8,8 +8,8 @@ FactoryGirl.define do
   end
 
   factory :typed_message_text, class: Threema::TypedMessage do
-    type    :text
-    message hello_world
+    type    { :text }
+    message { hello_world }
 
     initialize_with do
       new(attributes)

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,5 +1,5 @@
 require 'bundler/setup'
-require 'support/factory_girl'
+require 'support/factory_bot'
 require 'support/have_constant_matcher'
 require 'support/shared_values'
 require 'support/webmock_stubs'

--- a/spec/support/factory_bot.rb
+++ b/spec/support/factory_bot.rb
@@ -1,0 +1,9 @@
+require 'factory_bot'
+
+RSpec.configure do |config|
+  config.include FactoryBot::Syntax::Methods
+
+  config.before(:suite) do
+    FactoryBot.find_definitions
+  end
+end

--- a/spec/support/factory_girl.rb
+++ b/spec/support/factory_girl.rb
@@ -1,9 +1,0 @@
-require 'factory_girl'
-
-RSpec.configure do |config|
-  config.include FactoryGirl::Syntax::Methods
-
-  config.before(:suite) do
-    FactoryGirl.find_definitions
-  end
-end

--- a/threema.gemspec
+++ b/threema.gemspec
@@ -27,15 +27,15 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency 'mime-types'
   spec.add_runtime_dependency 'dotenv'
 
-  spec.add_development_dependency 'bundler', '~> 2.2'
-  spec.add_development_dependency 'rake', '~> 12'
-  spec.add_development_dependency 'rspec', '~> 3.0'
-  spec.add_development_dependency 'factory_girl', '~> 4.0'
-  spec.add_development_dependency 'webmock', '~> 2.3'
+  spec.add_development_dependency 'bundler'
+  spec.add_development_dependency 'rake'
+  spec.add_development_dependency 'rspec'
+  spec.add_development_dependency 'factory_bot'
+  spec.add_development_dependency 'webmock'
   spec.add_development_dependency 'fakefs'
   spec.add_development_dependency 'rubocop'
   spec.add_development_dependency 'simplecov'
   spec.add_development_dependency 'codeclimate-test-reporter', '~> 0.6'
-  spec.add_development_dependency 'codecov', '~> 0.1'
+  spec.add_development_dependency 'codecov'
 
 end


### PR DESCRIPTION
I only didn't update `codeclimate-test-reporter` as the gem is
deprecated altogether and I haven't looked into CI pipeline and
understood what's going on.

See: https://github.com/codeclimate/ruby-test-reporter

What was the reason to lift the version constraint on the development
dependencies? Well, there was no version constraint on the runtime
dependencies. I think, a version constraint on the runtime dependencies
would make more sense than on the development dependencies. So I decided
to remove them for the sake of consistency.
