### PR TITLE
feat: make static certificate pinning optional

### DIFF
--- a/lib/threema.rb
+++ b/lib/threema.rb
@@ -19,16 +19,12 @@ require 'threema/typed_message'
 class Threema
   attr_reader :client, :private_key, :api_identity, :api_secret
 
-  def initialize(api_identity: nil, api_secret: nil, private_key: nil, public_key_pinning: nil)
+  def initialize(api_identity: nil, api_secret: nil, private_key: nil)
     @api_identity = api_identity || ENV['THREEMARB_API_IDENTITY']
     @api_secret   = api_secret   || ENV['THREEMARB_API_SECRET']
     @private_key  = private_key  || ENV['THREEMARB_PRIVATE']
 
-    @client = Threema::Client.new(
-      api_identity: @api_identity,
-      api_secret: @api_secret,
-      public_key_pinning: public_key_pinning
-    )
+    @client = Threema::Client.new(threema: self)
   end
 
   def send(args)

--- a/spec/factories/threema_client.rb
+++ b/spec/factories/threema_client.rb
@@ -2,8 +2,7 @@
 
 FactoryBot.define do
   factory :threema_client, class: Threema::Client do
-    api_identity { test_from }
-    api_secret   { test_api_secret }
+    threema { FactoryBot.build(:threema) }
 
     initialize_with do
       new(attributes)


### PR DESCRIPTION
WHY: I chatted with Threema developers and one of them discouraged me
from implementing static certificate pinning because they have no workflow
to inform developers of upcoming changes to their HTTPS certificates.

So that's why we have at least
* get rid of the hardcoded HTTPS fingerprint, because it's
unmaintainable
* disable static certificate pinning by default

Nevertheless, @rugk writes that static certificate pinning is a useful
feature and does not suffer from the problems of HTTP public key
pinning, see: https://en.wikipedia.org/wiki/HTTP_Public_Key_Pinning

So I changed the source code in such a way that it's still possible to
configure the used HTTP client for certificate pinning as it used to be.

This commit includes a refactoring: DRY the threema client by passing a
reference to `threema` instance. Thus, the client does not have to
remember it's own `private_key`, `api_identity` and `api_secret`. Less
redundancy, less errors.

Fix #19

Merge after #22 and #23

I have questions: Why are `Threema` and `Threema::Client` two different classes? They seem very entangled.
