### PR TITLE
test: add `pry` as development dependency

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -5,6 +5,7 @@ require 'support/shared_values'
 require 'support/webmock_stubs'
 require 'webmock/rspec'
 require 'fakefs/spec_helpers'
+require 'pry'
 
 require 'simplecov'
 require 'codecov'

--- a/threema.gemspec
+++ b/threema.gemspec
@@ -33,6 +33,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'factory_bot'
   spec.add_development_dependency 'webmock'
   spec.add_development_dependency 'fakefs'
+  spec.add_development_dependency 'pry'
   spec.add_development_dependency 'rubocop'
   spec.add_development_dependency 'simplecov'
   spec.add_development_dependency 'codeclimate-test-reporter', '~> 0.6'


### PR DESCRIPTION
I find `pry` quite useful as a REPL during development and would like to know if anything speaks against adding it to the development dependencies?