### PR TITLE
feat: Implement a fallback class for not implemented message types

### DIFF
--- a/lib/threema/receive.rb
+++ b/lib/threema/receive.rb
@@ -9,6 +9,7 @@ require 'threema/util'
 require 'threema/receive/text'
 require 'threema/receive/image'
 require 'threema/receive/file'
+require 'threema/receive/delivery_receipt'
 
 class Threema
   module Receive

--- a/lib/threema/receive.rb
+++ b/lib/threema/receive.rb
@@ -10,6 +10,7 @@ require 'threema/receive/text'
 require 'threema/receive/image'
 require 'threema/receive/file'
 require 'threema/receive/delivery_receipt'
+require 'threema/receive/not_implemented_fallback'
 
 class Threema
   module Receive
@@ -58,7 +59,9 @@ class Threema
       end
 
       def classify(type)
-        Object.const_get(class_name(type))
+        return Object.const_get(class_name(type)) if Object.const_defined?(class_name(type))
+
+        Threema::Receive::NotImplementedFallback
       end
 
       def class_name(type)

--- a/lib/threema/receive/delivery_receipt.rb
+++ b/lib/threema/receive/delivery_receipt.rb
@@ -1,0 +1,11 @@
+class Threema
+  module Receive
+    class DeliveryReceipt
+      attr_reader :content
+
+      def initialize(content:, **)
+        @content = content
+      end
+    end
+  end
+end

--- a/lib/threema/receive/file.rb
+++ b/lib/threema/receive/file.rb
@@ -11,7 +11,7 @@ class Threema
     class File
       attr_reader :content, :mime_type, :name
 
-      def initialize(content:, threema:)
+      def initialize(content:, threema:, **)
         structure = JSON.parse(content)
 
         blob = Threema::Blob.new(threema: threema)

--- a/lib/threema/receive/not_implemented_fallback.rb
+++ b/lib/threema/receive/not_implemented_fallback.rb
@@ -2,7 +2,7 @@
 
 class Threema
   module Receive
-    class DeliveryReceipt
+    class NotImplementedFallback
       attr_reader :content
 
       def initialize(content:, **)

--- a/lib/threema/typed_message.rb
+++ b/lib/threema/typed_message.rb
@@ -11,7 +11,7 @@ class Threema
       survey_meta: "\x15".b, # NOT IMPLEMENTED YET
       survey_state: "\x16".b, # NOT IMPLEMENTED YET
       file: "\x17".b,
-      delivery_receipt: "\x80".b # NOT IMPLEMENTED YET
+      delivery_receipt: "\x80".b
     }.freeze
 
     class << self


### PR DESCRIPTION
Undraft and point the target branch to `master` once #26 is merged. The current target branch is just a convenience to make the diff a little smaller.

I included a hotfix commit by @mattwr18 in this PR. Other than that, here's my commit message:

    feat: avoid NameError on unimplemented mess. types

    @mattwr18 here is a test for your hotfix commit in the threema gem
    repo itself.

    @thorsteneckel we have deployed Matts commit already. Instead of
    removing the DeliveryClass, I decided to leave it in place to avoid
    integration issues. Is there something we could do about the delivery
    receipts?

How could `DeliveryReceipt` class a little more useful?
