### PR TITLE
build!: drop support for ruby < 2.6.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,11 @@
 sudo: false
 language: ruby
 rvm:
-  - 2.4.1
-  - 2.3.1
-  - 2.2.6
+  - 2.6.6
+  - 2.7.2
 before_install:
+  - sudo apt-get update
+  - sudo apt-get install -y libsodium-dev
   - gem update --system
   - gem --version
   - gem install bundler

--- a/threema.gemspec
+++ b/threema.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |spec|
   spec.homepage      = 'https://github.com/thorsteneckel/threema'
   spec.license       = 'MIT'
 
-  spec.required_ruby_version = '>= 2.4'
+  spec.required_ruby_version = '>= 2.6.0'
 
   spec.files         = Dir['{lib}/**/*']
   spec.require_paths = ['lib']


### PR DESCRIPTION
I'm upgrading to ruby v3 and found out that the error classes changed in bfc24c8446b5b45877fe35fb5e43e9632f23ef87 have to do with ruby's version.