### PR TITLE
fix: invalid syntax in ruby 3.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ language: ruby
 rvm:
   - 2.6.6
   - 2.7.2
+  - 3.0.0
 before_install:
   - sudo apt-get update
   - sudo apt-get install -y libsodium-dev

--- a/lib/threema.rb
+++ b/lib/threema.rb
@@ -35,7 +35,7 @@ class Threema
 
   def receive(args)
     args[:threema] = self
-    Threema::Receive.e2e(args)
+    Threema::Receive.e2e(**args)
   end
 
   private

--- a/lib/threema/receive.rb
+++ b/lib/threema/receive.rb
@@ -55,7 +55,7 @@ class Threema
       end
 
       def type_instance(type:, params:)
-        classify(type).new(params)
+        classify(type).new(**params)
       end
 
       def classify(type)

--- a/spec/factories/threema.rb
+++ b/spec/factories/threema.rb
@@ -6,7 +6,7 @@ FactoryBot.define do
     api_secret   { test_api_secret }
 
     initialize_with do
-      new(attributes)
+      new(**attributes)
     end
   end
 end

--- a/spec/factories/threema_account.rb
+++ b/spec/factories/threema_account.rb
@@ -5,7 +5,7 @@ FactoryBot.define do
     threema { FactoryBot.build(:threema) }
 
     initialize_with do
-      new(attributes)
+      new(**attributes)
     end
   end
 end

--- a/spec/factories/threema_blob.rb
+++ b/spec/factories/threema_blob.rb
@@ -5,7 +5,7 @@ FactoryBot.define do
     threema { FactoryBot.build(:threema) }
 
     initialize_with do
-      new(attributes)
+      new(**attributes)
     end
   end
 end

--- a/spec/factories/threema_capabilities.rb
+++ b/spec/factories/threema_capabilities.rb
@@ -5,7 +5,7 @@ FactoryBot.define do
     threema { FactoryBot.build(:threema) }
 
     initialize_with do
-      new(attributes)
+      new(**attributes)
     end
   end
 end

--- a/spec/factories/threema_client.rb
+++ b/spec/factories/threema_client.rb
@@ -5,7 +5,7 @@ FactoryBot.define do
     threema { FactoryBot.build(:threema) }
 
     initialize_with do
-      new(attributes)
+      new(**attributes)
     end
   end
 end

--- a/spec/factories/threema_file_message.rb
+++ b/spec/factories/threema_file_message.rb
@@ -9,7 +9,7 @@ FactoryBot.define do
     file       { hello_world.b }
 
     initialize_with do
-      new(attributes)
+      new(**attributes)
     end
   end
 end

--- a/spec/factories/threema_image_message.rb
+++ b/spec/factories/threema_image_message.rb
@@ -9,7 +9,7 @@ FactoryBot.define do
     image      { 'imagecontent'.b }
 
     initialize_with do
-      new(attributes)
+      new(**attributes)
     end
   end
 end

--- a/spec/factories/threema_lookup.rb
+++ b/spec/factories/threema_lookup.rb
@@ -5,7 +5,7 @@ FactoryBot.define do
     threema { FactoryBot.build(:threema) }
 
     initialize_with do
-      new(attributes)
+      new(**attributes)
     end
   end
 end

--- a/spec/factories/threema_send.rb
+++ b/spec/factories/threema_send.rb
@@ -5,7 +5,7 @@ FactoryBot.define do
     threema { FactoryBot.build(:threema) }
 
     initialize_with do
-      new(attributes)
+      new(**attributes)
     end
   end
 end

--- a/spec/factories/threema_simple_message.rb
+++ b/spec/factories/threema_simple_message.rb
@@ -6,7 +6,7 @@ FactoryBot.define do
     text       { hello_world }
 
     initialize_with do
-      new(attributes)
+      new(**attributes)
     end
   end
 
@@ -15,7 +15,7 @@ FactoryBot.define do
     text  { hello_world }
 
     initialize_with do
-      new(attributes)
+      new(**attributes)
     end
   end
 
@@ -24,7 +24,7 @@ FactoryBot.define do
     text  { hello_world }
 
     initialize_with do
-      new(attributes)
+      new(**attributes)
     end
   end
 end

--- a/spec/factories/threema_text_message.rb
+++ b/spec/factories/threema_text_message.rb
@@ -8,7 +8,7 @@ FactoryBot.define do
     public_key { nil }
 
     initialize_with do
-      new(attributes)
+      new(**attributes)
     end
   end
 end

--- a/spec/factories/threema_text_receive.rb
+++ b/spec/factories/threema_text_receive.rb
@@ -5,7 +5,7 @@ FactoryBot.define do
     content { hello_world }
 
     initialize_with do
-      new(attributes)
+      new(**attributes)
     end
   end
 end

--- a/spec/factories/threema_typed_message.rb
+++ b/spec/factories/threema_typed_message.rb
@@ -5,7 +5,7 @@ FactoryBot.define do
     typed { "\x01Hello World" }
 
     initialize_with do
-      new(attributes)
+      new(**attributes)
     end
   end
 
@@ -14,7 +14,7 @@ FactoryBot.define do
     message { hello_world }
 
     initialize_with do
-      new(attributes)
+      new(**attributes)
     end
   end
 end

--- a/spec/threema/receive/text_spec.rb
+++ b/spec/threema/receive/text_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe Threema::Receive::Text do
 
     it 'returns text content' do
       attributes = attributes_for(:text_receive)
-      instance = described_class.new(attributes)
+      instance = described_class.new(**attributes)
       expect(instance.content).to eq(attributes[:content])
     end
   end

--- a/spec/threema/receive_spec.rb
+++ b/spec/threema/receive_spec.rb
@@ -76,7 +76,7 @@ RSpec.describe Threema::Receive do
 
         mock_pubkey(attributes[:threema_id], test_public_key)
 
-        instance = Threema::Send::Text.new(attributes)
+        instance = Threema::Send::Text.new(**attributes)
 
         payload = instance.payload
 
@@ -102,7 +102,7 @@ RSpec.describe Threema::Receive do
     context 'for delivery receipts' do
       let(:initial_payload) do
         attributes = attributes_for(:text_message).merge(public_key: test_public_key)
-        Threema::Send::E2EBase.new(attributes).send(:generate_payload, :delivery_receipt, 'whatever')
+        Threema::Send::E2EBase.new(**attributes).send(:generate_payload, :delivery_receipt, 'whatever')
       end
 
       it 'creates instance of type Threema::Receive::DeliveryReceipt' do
@@ -113,7 +113,7 @@ RSpec.describe Threema::Receive do
     context 'for not yet implemented message types' do
       let(:initial_payload) do
         attributes = attributes_for(:text_message).merge(public_key: test_public_key)
-        Threema::Send::E2EBase.new(attributes).send(:generate_payload, :geo, 'whatever')
+        Threema::Send::E2EBase.new(**attributes).send(:generate_payload, :geo, 'whatever')
       end
 
       it 'creates instance of type Threema::Receive::DeliveryReceipt' do

--- a/spec/threema_spec.rb
+++ b/spec/threema_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe Threema do
         .to raise_error(ArgumentError)
     end
 
-    it 'tunnles send messages' do
+    it 'tunnels send messages' do
       %i[text image file].each do |message_type|
         attributes = attributes_for("#{message_type}_message".to_sym)
 
@@ -44,7 +44,7 @@ RSpec.describe Threema do
       expect(instance).to respond_to(:receive)
     end
 
-    it 'tunnles receive message' do
+    it 'tunnels receive message' do
       payload = {}
       expect(Threema::Receive).to receive(:e2e)
       instance.receive(payload)


### PR DESCRIPTION
See: https://www.ruby-lang.org/en/news/2019/12/12/separation-of-positional-and-keyword-arguments-in-ruby-3-0/