### PR TITLE
build: remove version constraint on active-support

### DIFF
--- a/lib/threema/send.rb
+++ b/lib/threema/send.rb
@@ -1,4 +1,6 @@
 # frozen_string_literal: true
+require 'active_support'
+require "active_support/core_ext"
 
 require 'threema/exceptions'
 require 'threema/send/simple'

--- a/threema.gemspec
+++ b/threema.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |spec|
   spec.files         = Dir['{lib}/**/*']
   spec.require_paths = ['lib']
 
-  spec.add_runtime_dependency 'activesupport', '<= 7.0.8'
+  spec.add_runtime_dependency 'activesupport'
   spec.add_runtime_dependency 'dotenv'
   spec.add_runtime_dependency 'mimemagic'
   spec.add_runtime_dependency 'mime-types'


### PR DESCRIPTION
Motivation
----------
This will require the Active Support Core extensions when needed. https://guides.rubyonrails.org/active_support_core_extensions.html

I think it's fine to lift the version constraint altogether.

How to test
-----------
1. `bundle install`
2. `bundle exec rake`
3. Tests pass (on my machine one test fails, but that's unrelated)